### PR TITLE
Allow specifying a search type

### DIFF
--- a/mediczuwacz.py
+++ b/mediczuwacz.py
@@ -117,7 +117,7 @@ class AppointmentFinder:
             )
             return {}
 
-    def find_appointments(self, region, specialty, clinic, start_date, end_date, language, doctor=None):
+    def find_appointments(self, search_type, region, specialty, clinic, start_date, end_date, language, doctor=None):
         appointment_url = "https://api-gateway-online24.medicover.pl/appointments/api/search-appointments/slots"
         params = {
             "RegionIds": region,
@@ -126,7 +126,7 @@ class AppointmentFinder:
             "Page": 1,
             "PageSize": 5000,
             "StartTime": start_date.isoformat(),
-            "SlotSearchType": 0,
+            "SlotSearchType": search_type,
             "VisitType": "Center",
         }
 
@@ -227,6 +227,7 @@ def main():
     subparsers = parser.add_subparsers(dest="command", required=True, help="Command to execute")
 
     find_appointment = subparsers.add_parser("find-appointment", help="Find appointment")
+    find_appointment.add_argument("--search-type", required=False, default="0", type=str, help="Search type")
     find_appointment.add_argument("-r", "--region", required=True, type=int, help="Region ID")
     find_appointment.add_argument("-s", "--specialty", required=True, type=int, action="extend", nargs="+", help="Specialty ID",)
     find_appointment.add_argument("-c", "--clinic", required=False, type=int, help="Clinic ID")
@@ -271,7 +272,7 @@ def main():
     
         if args.command == "find-appointment":
             # Find appointments
-            appointments = finder.find_appointments(args.region, args.specialty, args.clinic, args.date, args.enddate, args.language, args.doctor)
+            appointments = finder.find_appointments(args.search_type, args.region, args.specialty, args.clinic, args.date, args.enddate, args.language, args.doctor)
 
             # Find new appointments
             if previous_appointments:


### PR DESCRIPTION
This allows searching for diagnostic procedures (search type "DiagnosticProcedure" or "2" which is used for blood samples, USG, etc.) rather than standard visits (search type "Standard" or "0" which is now the default for the new flag).
Works well for me, managed to find a few quicker visits than what I had already :)