### PR TITLE
Ensure the start date is not in the past

### DIFF
--- a/mediczuwacz.py
+++ b/mediczuwacz.py
@@ -118,6 +118,9 @@ class AppointmentFinder:
             return {}
 
     def find_appointments(self, region, specialty, clinic, start_date, end_date, language, doctor=None):
+        today = datetime.date.today()
+        if start_date < today:
+            start_date = today
         appointment_url = "https://api-gateway-online24.medicover.pl/appointments/api/search-appointments/slots"
         params = {
             "RegionIds": region,


### PR DESCRIPTION
This is not required to make this project work since the API accepts past dates *but* it makes the API calls look closer to what you'd get when using UI (which, to my knowledge, doesn't allow selecting a date in the past as the start date).