### PR TITLE
Add search example for examinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ docker run --rm --env-file=.env mediczuwacz find-appointment -r 204 -s 112 -l 60
 docker run --rm --env-file=.env mediczuwacz find-appointment -r 204 -s 112 -i 10
 ```
 
+#### Example 7: Search for an examination / diagnostic procedure (USG jamy brzusznej - 521)
+Use `--search-type` param to search for appointments for a diagnostic procedure:
+```bash
+docker run --rm --env-file=.env mediczuwacz find-appointment -r 204 -s 521 --search-type DiagnosticProcedure
+```
+Note that some examinations may be classified the same as regular doctor appointments (e.g. blood tests).
+
+The known search types are (`0` is used when `--search-type` is not specified):
+
+- `Standard` / `0` - consultations and dentistry
+- `DiagnosticProcedure` / `2` - examinations
+
+Search types have a numeric and text values. The current web UI uses the text values.
+When trying to use the numeric values instead, the UI wrongfully shows the visits as paid even when they're included in your medical care package. This seems to be the only difference between numeric and text value - they appear to return the same appointments.
+
 ---
 
 ## How to Know IDs?


### PR DESCRIPTION
Follow-up to #15.
I'm not 100% sure that numeric values are not used at all, but they at least don't appear to be used in my Medicover OnLine view. I assume they're a leftover from the old Medicover web app. I described the difference in the README for anyone who might be interested.
I looked through the JSON output from the endpoint called by `list-filters` in the hope that the data would indicate what search type needs to be used for each speciality, but it doesn't seem like it does. This means that I don't really have a way to explain how to figure out the search type that needs to be used outside of just looking at query params in the URL when doing the same search through Medicover OnLine.

Also, there's not really a way for you to verify this flag because, afaik, you can't search for diagnostic procedures without having a referral for it (the only "examinations" the UI lets me select are blood samples, which use the `Standard` search type).

By the way, the merged #15 fixes #9.