### PR TITLE
Handle missing interactive terminal for 2FA input

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,19 @@ Easily track when your Medicover doctor has open appointments.
 
 Medicover requires 2FA. You must first configure your preferred 2FA method (e.g. email or SMS) in the Medicover Online web portal before using this tool.
 
-On the first run, you will be prompted to enter a verification code. After entering the code, the device is marked as trusted and session cookies are saved — subsequent runs will skip 2FA automatically.
+On the first run, you will be prompted to enter a verification code. Use the `-it` flag to enable interactive input:
+
+```bash
+docker run --rm -it --env-file=.env -v ~/.mediczuwacz:/data mediczuwacz find-appointment -r 204 -s 132
+```
+
+After entering the code, the device is marked as trusted and session cookies are saved — subsequent runs will skip 2FA automatically and no longer require `-it`.
 
 ---
 
 ## Usage
 
-All `docker run` commands below include `-v ~/.mediczuwacz:/data` to persist cookies and device ID between runs.
+All `docker run` commands below include `-v ~/.mediczuwacz:/data` to persist cookies and device ID between runs. Add `-it` if 2FA has not yet been completed.
 
 ### Run with Parameters
 #### Example 1: Search for an Appointment

--- a/mediczuwacz.py
+++ b/mediczuwacz.py
@@ -117,7 +117,11 @@ class Authenticator:
 
         # Prompt for 2FA code
         console.print(f"[bold yellow]2FA code required (channel: {form_data.get('Input.Channel', 'unknown')})[/bold yellow]")
-        code = input("Enter your 2FA code: ").strip()
+        try:
+            code = input("Enter your 2FA code: ").strip()
+        except EOFError:
+            console.print("[bold red]Cannot read 2FA code. Run with -it flag: docker run --rm -it ...[/bold red]")
+            raise SystemExit(1)
         if not code:
             raise ValueError("No 2FA code provided")
 


### PR DESCRIPTION
- Show clear error message when -it flag is missing instead of crashing
- Update README with -it flag instructions for first run